### PR TITLE
feat(css): add correct css hl with custom ts queries

### DIFF
--- a/lua/poimandres/highlights.lua
+++ b/lua/poimandres/highlights.lua
@@ -1,0 +1,4 @@
+require('nvim-treesitter.highlight').set_custom_captures {
+  ['classname'] = 'cssClassName',
+  ['pseudoclass'] = 'cssPseudoClass',
+}

--- a/lua/poimandres/init.lua
+++ b/lua/poimandres/init.lua
@@ -1,3 +1,4 @@
+require 'poimandres.highlights'
 local utils = require 'poimandres.utils'
 
 local M = {}

--- a/lua/poimandres/theme.lua
+++ b/lua/poimandres/theme.lua
@@ -114,7 +114,7 @@ function M.get(config)
     -- PreCondit     = { }, --  preprocessor #if, #else, #endif, etc.
 
     Type = { fg = p.blueGray1 }, -- (preferred) int, long, char, etc.
-    Structure = { fg = p.blueGray1 }, --  struct, union, enum, etc.
+    --[[ Structure = { fg = p.blueGray1 }, --  struct, union, enum, etc. ]]
     -- StorageClass  = { }, -- static, register, volatile, etc.
     -- Typedef = { fg = p.blueGray1 }, --  A typedef
 
@@ -258,6 +258,16 @@ function M.get(config)
 
     -- lua
     luaTSConstructor = { fg = p.blueGray1 },
+
+    -- css
+    cssTSFunction = { fg = p.blueGray1 },
+    cssTSProperty = { fg = p.blue2 },
+    cssTSType = { fg = p.teal1 },
+    cssTSKeyword = { fg = p.blueGray1 },
+    cssClassName = { fg = p.teal2, style = styles.italic },
+    cssPseudoClass = { fg = p.blue3, style = styles.italic },
+    cssDefinition = { fg = p.blue2 },
+    cssTSError = { link = 'cssClassName' },
 
     -- vim.lsp.buf.document_highlight()
     LspReferenceText = { bg = p.blue2 },

--- a/queries/css/highlights.scm
+++ b/queries/css/highlights.scm
@@ -1,0 +1,5 @@
+(class_selector (class_name) @classname) @classname
+(pseudo_class_selector (class_name) @pseudoclass) @pseudoclass
+(pseudo_element_selector (tag_name) @pseudoclass) @pseudoclass
+(plain_value) @operator
+(at_rule (keyword_query) @classname)


### PR DESCRIPTION
From what I've tested so far the CSS syntax highlighting should now be 95% accurate compared to the original vscode theme.
There are some limitations to treesitter which doesn't fully support @ rules with tailwind for example.

Closes #12 