### PR TITLE
feat: add semantic highlighting for falsy values (JS/TS/GO)

### DIFF
--- a/lua/poimandres/highlights.lua
+++ b/lua/poimandres/highlights.lua
@@ -1,4 +1,5 @@
 require('nvim-treesitter.highlight').set_custom_captures {
   ['classname'] = 'cssClassName',
   ['pseudoclass'] = 'cssPseudoClass',
+  ['constant.falsy'] = 'Error',
 }

--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -1,0 +1,4 @@
+[
+  (nil)
+  (false)
+] @constant.falsy

--- a/queries/javascript/highlights.scm
+++ b/queries/javascript/highlights.scm
@@ -1,0 +1,5 @@
+[
+  (false)
+  (null)
+  (undefined)
+] @constant.falsy

--- a/queries/typescript/highlights.scm
+++ b/queries/typescript/highlights.scm
@@ -1,0 +1,5 @@
+[
+  (false)
+  (null)
+  (undefined)
+] @constant.falsy


### PR DESCRIPTION
Adds custom JS/TS/GO queries for targeting falsy values.

![image](https://user-images.githubusercontent.com/47901349/188513105-25604bd7-f526-4f19-bd2b-ee3848b31851.png)

Closes #18 