### PR TITLE
feat(highlights): support lspsaga

### DIFF
--- a/lua/poimandres/theme.lua
+++ b/lua/poimandres/theme.lua
@@ -419,6 +419,74 @@ function M.get(config)
     NotifyERRORBorder = { fg = p.pink3 },
     NotifyERRORTitle = { link = 'NotifyERRORBorder' },
     NotifyERRORIcon = { link = 'NotifyERRORBorder' },
+
+    -- glepnir/lspsaga.nvim
+    TitleString = { fg = p.blue2 },
+    TitleIcon = { fg = p.blue2 },
+    SagaBorder = { bg = p.background2, fg = p.blueGray2 },
+    SagaNormal = { bg = p.background2 },
+    SagaExpand = { fg = p.teal2 },
+    SagaCollapse = { fg = p.teal2 },
+    SagaBeacon = { bg = p.yellow },
+    -- code action
+    ActionPreviewNormal = { link = 'SagaNormal' },
+    ActionPreviewBorder = { link = 'SagaBorder' },
+    ActionPreviewTitle = { fg = p.blueGray2, bg = p.background2 },
+    CodeActionNormal = { link = 'SagaNormal' },
+    CodeActionBorder = { link = 'SagaBorder' },
+    CodeActionText = { fg = p.yellow },
+    CodeActionNumber = { fg = p.blue3 },
+    -- finder
+    FinderSelection = { fg = p.blueGray2, bold = true },
+    FinderFileName = { fg = p.white },
+    FinderCount = { link = 'Label' },
+    FinderIcon = { fg = p.yellow },
+    FinderType = { fg = p.teal1 },
+    --finder spinner
+    FinderSpinnerTitle = { fg = p.pink3, bold = true },
+    FinderSpinner = { fg = p.pink3, bold = true },
+    FinderPreviewSearch = { link = 'Search' },
+    FinderVirtText = { fg = p.blue1 },
+    FinderNormal = { link = 'SagaNormal' },
+    FinderBorder = { link = 'SagaBorder' },
+    FinderPreviewBorder = { link = 'SagaBorder' },
+    -- definition
+    DefinitionBorder = { link = 'SagaBorder' },
+    DefinitionNormal = { link = 'SagaNormal' },
+    DefinitionSearch = { link = 'Search' },
+    -- hover
+    HoverNormal = { link = 'SagaNormal' },
+    HoverBorder = { link = 'SagaBorder' },
+    -- rename
+    RenameBorder = { link = 'SagaBorder' },
+    RenameNormal = { fg = p.white, p.background2 },
+    RenameMatch = { link = 'Search' },
+    -- diagnostic
+    DiagnosticBorder = { link = 'SagaBorder' },
+    DiagnosticSource = { fg = p.blueGray2 },
+    DiagnosticNormal = { link = 'SagaNormal' },
+    DiagnosticErrorBorder = { link = 'DiagnosticError' },
+    DiagnosticWarnBorder = { link = 'DiagnosticWarn' },
+    DiagnosticHintBorder = { link = 'DiagnosticHint' },
+    DiagnosticInfoBorder = { link = 'DiagnosticInfo' },
+    DiagnosticPos = { fg = p.blueGray2 },
+    DiagnosticWord = { fg = p.white },
+    -- Call Hierachry
+    CallHierarchyNormal = { link = 'SagaNormal' },
+    CallHierarchyBorder = { link = 'SagaBorder' },
+    CallHierarchyIcon = { fg = p.pink2 },
+    CallHierarchyTitle = { fg = p.pink2 },
+    -- lightbulb
+    LspSagaLightBulb = { link = 'DiagnosticSignHint' },
+    -- shadow
+    SagaShadow = { bg = p.background3 },
+    -- Outline
+    OutlineIndent = { fg = p.blue2 },
+    OutlinePreviewBorder = { link = 'SagaNormal' },
+    OutlinePreviewNormal = { link = 'SagaBorder' },
+    -- Float term
+    TerminalBorder = { link = 'SagaBorder' },
+    TerminalNormal = { link = 'SagaNormal' },
   }
 
   vim.g.terminal_color_0 = p.background3 -- black


### PR DESCRIPTION
Add support for [lspsaga.nvim](https://github.com/glepnir/lspsaga.nvim)

## Some screenshots with the added hightlights: 
![Hover](https://user-images.githubusercontent.com/54907476/215437180-4583ac68-74ee-4d0d-86ee-0a07dc48018f.png)
![Rename](https://user-images.githubusercontent.com/54907476/215437205-d8b381a7-730c-44b1-b715-02c406b56485.png)
![Find](https://user-images.githubusercontent.com/54907476/215437220-614e8e29-be5b-4eba-a491-54e870a92a54.png)
![Error](https://user-images.githubusercontent.com/54907476/215437234-4f0892de-ae0c-4da3-804d-68c79e858b7d.png)
![CodeActions](https://user-images.githubusercontent.com/54907476/215437257-7aa8f0e0-1dd1-45fa-9bb2-39449488f88c.png)

## How it looks without the added highlights (without changes):
![BeforeHover](https://user-images.githubusercontent.com/54907476/215437370-a537b76a-a210-4d41-9e19-d972b8da6025.png)
![BeforeFind](https://user-images.githubusercontent.com/54907476/215437409-8e0990d4-558e-45cc-abf2-e60434c742bf.png)
![BeforeError](https://user-images.githubusercontent.com/54907476/215437421-f3779249-f4bf-4621-949e-82cbc0ceb09b.png)

I think the newly added highlights go better with the overall theme, even though it could use some tuning...