### PR TITLE
feat: added typescript queries for better highlights

### DIFF
--- a/after/queries/typescript/highlights.scm
+++ b/after/queries/typescript/highlights.scm
@@ -1,0 +1,22 @@
+;; extends
+"export" @keyword.export
+"import" @keyword.import
+
+[
+ (undefined)
+ (null)
+ (false)
+] @constant.falsy
+
+(import_clause 
+  [
+    (identifier) @import.identifier
+    (named_imports (import_specifier 
+      [
+        name: (identifier) @import.identifier
+        alias: (identifier) @import.identifier
+      ]
+    ))
+    (namespace_import (identifier) @import.identifier)
+  ]
+)

--- a/lua/poimandres/theme.lua
+++ b/lua/poimandres/theme.lua
@@ -200,6 +200,7 @@ function M.get(config)
     -- TSConditional = { link = 'Conditional' },
     ['@variable.builtin'] = { fg = p.blue2 },
     ['@constant.builtin'] = { fg = p.blue2 },
+    ['@constant.falsy'] = { fg = p.pink3 },
     -- TSConstMacro = {},
     -- TSConstant = { fg = p.text },
     ['@constructor'] = { fg = p.teal1 },
@@ -211,7 +212,7 @@ function M.get(config)
     ['@function.builtin'] = { fg = p.blue2 },
     -- TSFuncMacro = {},
     ['@function'] = { link = 'Function' },
-    ['@function.call'] = { fg = p.text },
+    ['@function.call'] = { fg = p.blueGray1 },
     TSInclude = { fg = p.blue2 },
     ['@keyword'] = { link = 'Keyword' },
     ['@keyword.return'] = { fg = p.teal2 },
@@ -247,7 +248,15 @@ function M.get(config)
     TSURI = { fg = groups.link },
     -- TSUnderline = {},
 
-    -- tsx/jsx
+    -- tsx
+    ['@keyword.export.tsx'] = { fg = p.teal1 },
+    ['@keyword.import.tsx'] = { fg = p.teal1 },
+    ['@import.identifier.tsx'] = { fg = p.blue2 },
+
+    -- typescript
+    ['@keyword.export.typescript'] = { fg = p.teal1 },
+    ['@keyword.import.typescript'] = { fg = p.teal1 },
+    ['@import.identifier.typescript'] = { fg = p.blue2 },
     typescriptVariable = { fg = p.blue2 },
     typescriptExport = { fg = p.teal1 },
     typescriptDefault = { fg = p.teal1 },


### PR DESCRIPTION
Add highlight groups for typescript to better match the poimandres theme.

- import, export
- import identifiers
- falsy values
- function calls with darker color

I noticed you already worked on some queries but later disabled it, so Iam not sure if it was working before. Didnt make changes in your existing queries and highlight groups.