### PR TITLE
Switched to Lua comment operators in vim-plug example

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ Plug 'olivercederborg/poimandres.nvim'
 
 lua << EOF
   require('poimandres').setup {
-    " leave this setup function empty for default config
-    " or refer to the configuration section
-    " for configuration options
+    -- leave this setup function empty for default config
+    -- or refer to the configuration section
+    -- for configuration options
   }
 EOF
 ```


### PR DESCRIPTION
Switched to Lua comment operators in vim-plug example inside `README.md`