### PR TITLE
[FIX] Change `vim.lsp.buf.document_highlight` group to more visible one

### DIFF
--- a/lua/poimandres/theme.lua
+++ b/lua/poimandres/theme.lua
@@ -284,9 +284,9 @@ function M.get(config)
     cssTSError = { link = 'cssClassName' },
 
     -- vim.lsp.buf.document_highlight()
-    LspReferenceText = { bg = p.blue2 },
-    LspReferenceRead = { bg = p.blue2 },
-    LspReferenceWrite = { bg = p.blue2 },
+    LspReferenceText = { link = 'Visual' },
+    LspReferenceRead = { link = 'Visual' },
+    LspReferenceWrite = { link = 'Visual' },
 
     -- lsp-highlight-codelens
     LspCodeLens = { fg = p.blueGray1 }, -- virtual text of code lens


### PR DESCRIPTION
Hi there @olivercederborg. first of all thank you for this beautiful theme.

It is really great. But there is small bug for `vim.lsp.buf.document_highlight` groups. It is almost impossible to see the text under the cursor when `LspRefrence{Text,Read,Write}` group are applied to current word.

I link those problem causing groups to `Visual` group. Now we `document_highlight` looks perfect and text is fully readable.

Hoping I am able to describe the problem correctly :smiley: